### PR TITLE
Feat/add start stop guards

### DIFF
--- a/workhours/main.py
+++ b/workhours/main.py
@@ -47,7 +47,7 @@ def status():
         time_difference = (date - datetime.strptime(last_date, FORMAT)).total_seconds()
         working_hours = time_difference // 3600
         working_minutes = (time_difference - (working_hours * 3600)) // 60
-        click.echo(f"You have been working for {int(working_hours)} hours and {int(working_minutes)} minutes.")
+        click.echo(f"You have focused for {int(working_hours)} hours and {int(working_minutes)} minutes.")
     else:
         click.echo(f"Last action not recognized: {last_action}")
 

--- a/workhours/main.py
+++ b/workhours/main.py
@@ -54,16 +54,30 @@ def status():
 @cli.command()
 def hi():
     """Start counting work hours."""
-    date = get_current_time()
-    save_hours(date, "start")
-    click.echo(f"Tracking working hours started at {date.strftime(FORMAT)}")
+    last_entry = get_last_entry()
+    last_date, last_action = last_entry
+    if last_action == "start":
+        click.echo("You're already working.")
+    elif last_action == "stop":
+        date = get_current_time()
+        save_hours(date, "start")
+        click.echo(f"Tracking working hours started at {date.strftime(FORMAT)}")
+    else:
+        click.echo(f"Last action not recognized: {last_action}")
 
 @cli.command()
 def bye():
     """Stop counting work hours."""
-    date = get_current_time()
-    save_hours(date, "stop")
-    click.echo(f"Tracking work hours stoped at {date.strftime(FORMAT)}")
+    last_entry = get_last_entry()
+    last_date, last_action = last_entry
+    if last_action == "stop":
+        click.echo("You already stopped working.")
+    elif last_action == "start":
+        date = get_current_time()
+        save_hours(date, "stop")
+        click.echo(f"Tracking work hours stopped at {date.strftime(FORMAT)}")
+    else:
+        click.echo(f"Last action not recognized: {last_action}")
 
 if __name__ == "__main__":
     cli()


### PR DESCRIPTION
This PR adds guards to avoid starting or stopping the tracking of hours when the same command is already ongoing.
For example, today you start working at 8am with the hi subcommand, you forget about starting the application and at 8:30 you call the start subcommand again - the application accepts this flow and it leads to inconsistencies in tracked hours.